### PR TITLE
Fix response schema

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -126,10 +126,7 @@ async function main() {
     contents: messages,
     config: {
       responseMimeType: "application/json",
-      responseSchema: {
-        type: Type.OBJECT,
-        properties
-      },
+      responseSchema: properties,
     },
   });
 
@@ -146,7 +143,7 @@ async function main() {
   }
 
   if (parsedResponse.status && parsedResponse.status === "ACTION") {
-    toolBox[parsedResponse.tool]([...parsedResponse.parms]);
+    toolBox[parsedResponse.tool]([...parsedResponse.params]);
   }
 
   if (parsedResponse.status && parsedResponse.status === "OUTPUT") {


### PR DESCRIPTION
Closes #1 

In the documentation responseSchema: properties but the issue was responseSchema: { properties }

Output: { message: 'Give me the sum of 1000 and 1000', status: 'START' }
Give me the sum of 1000 and 1000